### PR TITLE
feat: support SSE speech streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,9 +174,47 @@ Request fields:
 | `voice` | string or object | no | Voice ID, or `{ "id": "voice_id" }`. Uses `IRODORI_DEFAULT_VOICE` if omitted. |
 | `response_format` | string | no | `wav`, `mp3`, `flac`, `opus`, `aac`, or `pcm`. |
 | `speed` | number | no | Speaking speed, from `0.25` to `4.0`. Higher is faster; internally this is converted to an inverse duration scale. |
+| `stream_format` | string | no | Set to `sse` to receive chunk-level Server-Sent Events. |
 | `irodori` | object | no | Irodori-specific inference options. |
 
-`stream_format: "sse"` is rejected because streaming synthesis is not supported.
+When `stream_format: "sse"` is set, the response is `text/event-stream`.
+The server synthesizes each text chunk sequentially and emits one `audio_chunk`
+event per chunk, followed by a final `done` event:
+
+For consistent voice tone across chunks, specify a reference voice with `voice`
+or `irodori.ref_wav`. Without a reference, each chunk is synthesized
+independently and the perceived voice tone may vary between chunks.
+
+```bash
+curl -N http://localhost:8088/v1/audio/speech \
+  -H "Content-Type: application/json" \
+  -H "Accept: text/event-stream" \
+  -d '{
+    "model": "irodori-tts",
+    "input": "最初の文です。次の文です。",
+    "voice": "sample",
+    "response_format": "wav",
+    "stream_format": "sse",
+    "irodori": {
+      "chunking_enabled": true,
+      "chunk_min_chars": 1
+    }
+  }'
+```
+
+```text
+event: audio_chunk
+data: {"index":0,"text":"最初の文です。","format":"wav","media_type":"audio/wav","audio_base64":"...","seed":123,"total_to_decode":0.1}
+
+event: audio_chunk
+data: {"index":1,"text":"次の文です。","format":"wav","media_type":"audio/wav","audio_base64":"...","seed":123,"total_to_decode":0.1}
+
+event: done
+data: {"chunks":2}
+```
+
+Each `audio_base64` value contains a complete audio file for that chunk, so
+clients can decode and enqueue chunks while later chunks are still generating.
 
 Irodori-specific options:
 

--- a/src/irodori_openai_tts/app.py
+++ b/src/irodori_openai_tts/app.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import asyncio
+import base64
+import json
 import logging
 import time
-from collections.abc import Mapping
+from collections.abc import AsyncIterator, Mapping
 from contextlib import asynccontextmanager
 from dataclasses import replace
 from functools import partial
@@ -13,7 +15,7 @@ import torch
 from fastapi import Depends, FastAPI, File, Form, Header, HTTPException, Request, UploadFile
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import JSONResponse, Response
+from fastapi.responses import JSONResponse, Response, StreamingResponse
 from pydantic import BaseModel, ConfigDict, Field
 
 from irodori_tts.inference_runtime import SamplingRequest, SamplingResult
@@ -298,11 +300,7 @@ def delete_voice(voice_id: str) -> dict[str, Any]:
 @app.post("/v1/audio/speech", dependencies=[Depends(require_auth)])
 async def create_speech(payload: SpeechRequest) -> Response:
     _validate_speech_payload(payload)
-    if payload.stream_format is not None and str(payload.stream_format).lower() == "sse":
-        raise HTTPException(
-            status_code=400,
-            detail="stream_format='sse' is not supported by this non-streaming model.",
-        )
+    stream_as_sse = _stream_format_is_sse(payload.stream_format)
 
     try:
         response_format = normalize_response_format(
@@ -328,6 +326,15 @@ async def create_speech(payload: SpeechRequest) -> Response:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     except TypeError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    if stream_as_sse:
+        return _stream_speech_response(
+            sampling_request,
+            chunks,
+            response_format,
+            request_started_at,
+        )
+
     try:
         runtime = await _run_blocking(runtime_manager.get)
     except RuntimeLoadTimeoutError as exc:
@@ -369,6 +376,18 @@ async def create_speech(payload: SpeechRequest) -> Response:
         content=audio_bytes,
         media_type=CONTENT_TYPES[response_format],
         headers=headers,
+    )
+
+
+def _stream_format_is_sse(stream_format: str | None) -> bool:
+    if stream_format is None:
+        return False
+    value = str(stream_format).strip().lower()
+    if value == "sse":
+        return True
+    raise HTTPException(
+        status_code=400,
+        detail="stream_format must be 'sse' when specified.",
     )
 
 
@@ -550,6 +569,132 @@ async def _synthesize_chunks(
         used_seed=results[0].used_seed,
         messages=messages,
     )
+
+
+def _stream_speech_response(
+    sampling_request: SamplingRequest,
+    chunks: list[str],
+    response_format: str,
+    request_started_at: float,
+) -> StreamingResponse:
+    async def events() -> AsyncIterator[str]:
+        synthesis_semaphore: asyncio.Semaphore | None = None
+        completed = 0
+        try:
+            runtime = await _run_blocking(runtime_manager.get)
+            synthesis_semaphore = await _acquire_synthesis_slot()
+            for index, chunk in enumerate(chunks):
+                logger.info(
+                    "speech stream chunk %d/%d started: chars=%d",
+                    index + 1,
+                    len(chunks),
+                    len(chunk),
+                )
+                chunk_request = replace(sampling_request, text=chunk)
+                result = await _run_stream_blocking(
+                    runtime.synthesize,
+                    chunk_request,
+                    log_fn=_log_runtime_message,
+                )
+                audio_bytes = await _run_stream_blocking(
+                    encode_audio,
+                    result.audio,
+                    result.sample_rate,
+                    response_format,
+                )
+                completed += 1
+                logger.info(
+                    "speech stream chunk %d/%d completed: audio_seconds=%.2f bytes=%d",
+                    index + 1,
+                    len(chunks),
+                    _audio_duration_seconds(result.audio, result.sample_rate),
+                    len(audio_bytes),
+                )
+                yield _sse_event(
+                    "audio_chunk",
+                    {
+                        "index": index,
+                        "text": chunk,
+                        "format": response_format,
+                        "media_type": CONTENT_TYPES[response_format],
+                        "audio_base64": base64.b64encode(audio_bytes).decode("ascii"),
+                        "seed": result.used_seed,
+                        "total_to_decode": result.total_to_decode,
+                    },
+                )
+        except RuntimeLoadTimeoutError as exc:
+            yield _sse_error_event(str(exc), error_type="server_error", code="runtime_unavailable")
+            return
+        except HTTPException as exc:
+            yield _sse_openai_error_event(exc)
+            return
+        except (FileNotFoundError, ValueError) as exc:
+            yield _sse_error_event(str(exc), code="invalid_request")
+            return
+        except RuntimeError as exc:
+            error_type = (
+                "invalid_request_error"
+                if "Dynamic LoRA loading is not compatible" in str(exc)
+                else "server_error"
+            )
+            yield _sse_error_event(str(exc), error_type=error_type, code="stream_error")
+            return
+        else:
+            logger.info(
+                "speech stream completed: elapsed=%.2fs chunks=%d",
+                time.perf_counter() - request_started_at,
+                completed,
+            )
+            yield _sse_event("done", {"chunks": completed})
+        finally:
+            if synthesis_semaphore is not None:
+                _release_synthesis_slot(synthesis_semaphore)
+
+    return StreamingResponse(
+        events(),
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+    )
+
+
+async def _run_stream_blocking(func: Any, *args: Any, **kwargs: Any) -> Any:
+    task = asyncio.create_task(_run_blocking(func, *args, **kwargs))
+    try:
+        return await asyncio.shield(task)
+    except asyncio.CancelledError:
+        await task
+        raise
+
+
+def _sse_event(event: str, data: dict[str, Any]) -> str:
+    payload = json.dumps(data, ensure_ascii=False, separators=(",", ":"))
+    return f"event: {event}\ndata: {payload}\n\n"
+
+
+def _sse_error_event(
+    message: str,
+    *,
+    error_type: str = "invalid_request_error",
+    code: str,
+    param: str | None = None,
+) -> str:
+    return _sse_event(
+        "error",
+        {
+            "error": {
+                "message": message,
+                "type": error_type,
+                "param": param,
+                "code": code,
+            }
+        },
+    )
+
+
+def _sse_openai_error_event(exc: HTTPException) -> str:
+    error_type = "invalid_request_error" if exc.status_code < 500 else "server_error"
+    code = "synthesis_queue_timeout" if exc.status_code == 503 else "stream_error"
+    return _sse_error_event(str(exc.detail), error_type=error_type, code=code)
 
 
 def _log_runtime_message(message: str) -> None:

--- a/src/irodori_openai_tts/app.py
+++ b/src/irodori_openai_tts/app.py
@@ -578,11 +578,9 @@ def _stream_speech_response(
     request_started_at: float,
 ) -> StreamingResponse:
     async def events() -> AsyncIterator[str]:
-        synthesis_semaphore: asyncio.Semaphore | None = None
         completed = 0
         try:
             runtime = await _run_blocking(runtime_manager.get)
-            synthesis_semaphore = await _acquire_synthesis_slot()
             for index, chunk in enumerate(chunks):
                 logger.info(
                     "speech stream chunk %d/%d started: chars=%d",
@@ -591,11 +589,15 @@ def _stream_speech_response(
                     len(chunk),
                 )
                 chunk_request = replace(sampling_request, text=chunk)
-                result = await _run_stream_blocking(
-                    runtime.synthesize,
-                    chunk_request,
-                    log_fn=_log_runtime_message,
-                )
+                synthesis_semaphore = await _acquire_synthesis_slot()
+                try:
+                    result = await _run_stream_blocking(
+                        runtime.synthesize,
+                        chunk_request,
+                        log_fn=_log_runtime_message,
+                    )
+                finally:
+                    _release_synthesis_slot(synthesis_semaphore)
                 audio_bytes = await _run_stream_blocking(
                     encode_audio,
                     result.audio,
@@ -646,9 +648,6 @@ def _stream_speech_response(
                 completed,
             )
             yield _sse_event("done", {"chunks": completed})
-        finally:
-            if synthesis_semaphore is not None:
-                _release_synthesis_slot(synthesis_semaphore)
 
     return StreamingResponse(
         events(),

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import asyncio
+import base64
+import json
 import threading
 
 import pytest
@@ -62,6 +64,27 @@ class NeverAvailableSemaphore:
 
     def release(self):
         raise AssertionError("release should not be called when acquire times out")
+
+
+class RecordingSemaphore:
+    def __init__(self) -> None:
+        self.released = False
+
+    async def acquire(self):
+        return True
+
+    def release(self):
+        self.released = True
+
+
+def sse_events(text: str) -> list[tuple[str, dict]]:
+    events = []
+    for block in text.strip().split("\n\n"):
+        lines = block.splitlines()
+        event = next(line.removeprefix("event: ") for line in lines if line.startswith("event: "))
+        data = next(line.removeprefix("data: ") for line in lines if line.startswith("data: "))
+        events.append((event, json.loads(data)))
+    return events
 
 
 def test_health_does_not_load_model(tmp_path, monkeypatch):
@@ -187,7 +210,7 @@ def test_speech_returns_503_when_model_is_loading(monkeypatch):
     assert "Model is still loading" in response.json()["error"]["message"]
 
 
-def test_speech_rejects_sse_stream_format_before_loading_runtime(monkeypatch):
+def test_speech_stream_format_sse_emits_audio_chunk(monkeypatch):
     runtime = FakeRuntime()
     monkeypatch.setattr(main, "runtime_manager", FakeRuntimeManager(runtime=runtime))
 
@@ -197,11 +220,45 @@ def test_speech_rejects_sse_stream_format_before_loading_runtime(monkeypatch):
             "model": "irodori-tts",
             "input": "こんにちは。",
             "voice": "none",
+            "response_format": "wav",
             "stream_format": "sse",
         },
     )
 
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/event-stream")
+    assert runtime.texts == ["こんにちは。"]
+    events = sse_events(response.text)
+    assert [event for event, _data in events] == ["audio_chunk", "done"]
+    audio_chunk = events[0][1]
+    assert audio_chunk["index"] == 0
+    assert audio_chunk["text"] == "こんにちは。"
+    assert audio_chunk["format"] == "wav"
+    assert audio_chunk["media_type"] == "audio/wav"
+    assert audio_chunk["seed"] == 123
+    assert audio_chunk["total_to_decode"] == 0.1
+    assert base64.b64decode(audio_chunk["audio_base64"]).startswith(b"RIFF")
+    assert events[1][1] == {"chunks": 1}
+
+
+def test_speech_rejects_unknown_stream_format_before_loading_runtime(monkeypatch):
+    runtime = FakeRuntime()
+    manager = FakeRuntimeManager(runtime=runtime)
+    monkeypatch.setattr(main, "runtime_manager", manager)
+
+    response = TestClient(main.app).post(
+        "/v1/audio/speech",
+        json={
+            "model": "irodori-tts",
+            "input": "こんにちは。",
+            "voice": "none",
+            "stream_format": "jsonl",
+        },
+    )
+
     assert response.status_code == 400
+    assert "stream_format" in response.json()["error"]["message"]
+    assert manager.thread_ids == []
     assert runtime.texts == []
 
 
@@ -472,6 +529,128 @@ def test_speech_returns_503_when_synthesis_queue_times_out(monkeypatch):
     assert runtime.texts == []
 
 
+def test_speech_stream_format_sse_returns_queue_timeout_as_error_event(monkeypatch):
+    runtime = FakeRuntime()
+    monkeypatch.setattr(main, "runtime_manager", FakeRuntimeManager(runtime=runtime))
+    monkeypatch.setattr(main.settings, "synthesis_wait_timeout", 0.01)
+    monkeypatch.setattr(main.settings, "max_concurrent_synthesis", 1)
+    monkeypatch.setattr(main, "_synthesis_semaphore", NeverAvailableSemaphore())
+    monkeypatch.setattr(main, "_synthesis_semaphore_limit", 1)
+
+    response = TestClient(main.app).post(
+        "/v1/audio/speech",
+        json={
+            "model": "irodori-tts",
+            "input": "こんにちは。",
+            "voice": "none",
+            "response_format": "wav",
+            "stream_format": "sse",
+        },
+    )
+
+    assert response.status_code == 200
+    assert sse_events(response.text) == [
+        (
+            "error",
+            {
+                "error": {
+                    "message": "Synthesis queue is full. Retry after a moment. timeout=0.0s",
+                    "type": "server_error",
+                    "param": None,
+                    "code": "synthesis_queue_timeout",
+                }
+            },
+        )
+    ]
+    assert runtime.texts == []
+
+
+def test_speech_stream_format_sse_returns_runtime_error_event(monkeypatch):
+    runtime = FakeRuntime(exc=ValueError("runtime validation failed"))
+    monkeypatch.setattr(main, "runtime_manager", FakeRuntimeManager(runtime=runtime))
+
+    response = TestClient(main.app).post(
+        "/v1/audio/speech",
+        json={
+            "model": "irodori-tts",
+            "input": "こんにちは。",
+            "voice": "none",
+            "response_format": "wav",
+            "stream_format": "sse",
+        },
+    )
+
+    assert response.status_code == 200
+    assert sse_events(response.text) == [
+        (
+            "error",
+            {
+                "error": {
+                    "message": "runtime validation failed",
+                    "type": "invalid_request_error",
+                    "param": None,
+                    "code": "invalid_request",
+                }
+            },
+        )
+    ]
+
+
+def test_speech_stream_format_sse_holds_slot_until_cancelled_synthesis_finishes(monkeypatch):
+    semaphore = RecordingSemaphore()
+
+    async def run_test():
+        started = asyncio.Event()
+        release_synthesis = asyncio.Event()
+        main_thread_loop = asyncio.get_running_loop()
+
+        class SlowRuntime:
+            def synthesize(self, req, *, log_fn=None):
+                main_thread_loop.call_soon_threadsafe(started.set)
+                asyncio.run_coroutine_threadsafe(
+                    release_synthesis.wait(), main_thread_loop
+                ).result()
+                audio = torch.zeros(1, max(1, len(req.text)) * 10)
+                return SamplingResult(
+                    audio=audio,
+                    audios=[audio],
+                    sample_rate=1000,
+                    stage_timings=[],
+                    total_to_decode=0.1,
+                    used_seed=123,
+                    messages=[],
+                )
+
+        monkeypatch.setattr(main, "runtime_manager", FakeRuntimeManager(runtime=SlowRuntime()))
+
+        response = main._stream_speech_response(
+            main.SamplingRequest(text="こんにちは。", no_ref=True),
+            ["こんにちは。"],
+            "wav",
+            0.0,
+        )
+        stream = response.body_iterator
+        task = asyncio.create_task(stream.__anext__())
+
+        await asyncio.wait_for(started.wait(), timeout=1)
+        task.cancel()
+        await asyncio.sleep(0)
+        assert semaphore.released is False
+
+        release_synthesis.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert semaphore.released is True
+
+    async def fake_acquire_synthesis_slot():
+        await semaphore.acquire()
+        return semaphore
+
+    monkeypatch.setattr(main, "_acquire_synthesis_slot", fake_acquire_synthesis_slot)
+
+    asyncio.run(run_test())
+
+
 def test_speech_chunking_can_be_disabled_per_request(monkeypatch):
     runtime = FakeRuntime()
     monkeypatch.setattr(main, "runtime_manager", FakeRuntimeManager(runtime=runtime))
@@ -523,6 +702,39 @@ def test_speech_chunking_splits_only_after_min_chars(monkeypatch):
     assert len(runtime.texts) == 2
     assert runtime.texts[0].endswith("。")
     assert runtime.texts[1] == "最後です。"
+
+
+def test_speech_stream_format_sse_emits_each_chunk(monkeypatch):
+    runtime = FakeRuntime()
+    monkeypatch.setattr(main, "runtime_manager", FakeRuntimeManager(runtime=runtime))
+    text = (
+        "これは短い文です。これはまだ同じチャンクに残る文です。"
+        "ここまでで十分長くなったので分割されます。最後です。"
+    )
+
+    response = TestClient(main.app).post(
+        "/v1/audio/speech",
+        json={
+            "model": "irodori-tts",
+            "input": text,
+            "voice": "none",
+            "response_format": "wav",
+            "stream_format": "sse",
+            "irodori": {
+                "chunking_enabled": True,
+                "chunk_min_chars": 35,
+            },
+        },
+    )
+
+    assert response.status_code == 200
+    assert len(runtime.texts) == 2
+    events = sse_events(response.text)
+    assert [event for event, _data in events] == ["audio_chunk", "audio_chunk", "done"]
+    assert [data["text"] for _event, data in events[:2]] == runtime.texts
+    assert events[0][1]["index"] == 0
+    assert events[1][1]["index"] == 1
+    assert events[2][1] == {"chunks": 2}
 
 
 def test_speech_chunking_skips_when_seconds_is_explicit(monkeypatch):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -596,6 +596,31 @@ def test_speech_stream_format_sse_returns_runtime_error_event(monkeypatch):
     ]
 
 
+def test_speech_stream_format_sse_releases_slot_before_yielding_chunk(monkeypatch):
+    semaphore = RecordingSemaphore()
+    runtime = FakeRuntime()
+    monkeypatch.setattr(main, "runtime_manager", FakeRuntimeManager(runtime=runtime))
+
+    async def fake_acquire_synthesis_slot():
+        await semaphore.acquire()
+        return semaphore
+
+    monkeypatch.setattr(main, "_acquire_synthesis_slot", fake_acquire_synthesis_slot)
+
+    async def run_test():
+        response = main._stream_speech_response(
+            main.SamplingRequest(text="こんにちは。", no_ref=True),
+            ["こんにちは。"],
+            "wav",
+            0.0,
+        )
+        chunk = await response.body_iterator.__anext__()
+        assert chunk.startswith("event: audio_chunk\n")
+        assert semaphore.released is True
+
+    asyncio.run(run_test())
+
+
 def test_speech_stream_format_sse_holds_slot_until_cancelled_synthesis_finishes(monkeypatch):
     semaphore = RecordingSemaphore()
 


### PR DESCRIPTION
## Summary
- Add `stream_format: "sse"` support to `POST /v1/audio/speech` with chunk-level Server-Sent Events.
- Emit `audio_chunk` events containing base64-encoded complete audio for each generated text chunk, followed by a final `done` event.
- Keep the synthesis concurrency slot held until in-flight streaming synthesis work finishes, even if the SSE response is cancelled.
- Document the SSE request and event format in the README.

## Testing
- `PYENV_VERSION=3.12.12 uv run --extra dev pytest -q tests/test_api.py`
- `PYENV_VERSION=3.12.12 uv run --extra dev ruff check src/irodori_openai_tts/app.py tests/test_api.py`
- `PYENV_VERSION=3.12.12 uv run --extra dev ruff format --check src/irodori_openai_tts/app.py tests/test_api.py`