### PR TITLE
Captionテキストの対応

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,7 @@ IRODORI_TTS_BACKEND=cu128
 # IRODORI_API_KEY=change-me
 
 # Model
-IRODORI_HF_CHECKPOINT=Aratako/Irodori-TTS-500M-v3
+IRODORI_HF_CHECKPOINT=Aratako/Irodori-TTS-600M-v3-VoiceDesign
 # IRODORI_CHECKPOINT=/models/model.safetensors
 IRODORI_CODEC_REPO=Aratako/Semantic-DACVAE-Japanese-32dim
 IRODORI_MODEL_NAME=irodori-tts

--- a/src/irodori_openai_tts/app.py
+++ b/src/irodori_openai_tts/app.py
@@ -34,11 +34,12 @@ _synthesis_semaphore_limit: int | None = None
 class IrodoriOptions(BaseModel):
     model_config = ConfigDict(extra="allow")
 
-    caption: str | None = None
     ref_wav: str | None = None
     ref_latent: str | None = None
-    ref_embed: str | None = None
     no_ref: bool | None = None
+    caption: str | None = None
+    max_caption_len: int | None = None
+    cfg_scale_caption: float | None = None
     seconds: float | None = None
     duration_scale: float | None = None
     min_seconds: float | None = None
@@ -52,7 +53,6 @@ class IrodoriOptions(BaseModel):
     num_candidates: int | None = None
     decode_mode: Literal["sequential", "batch"] | None = None
     cfg_scale_text: float | None = None
-    cfg_scale_caption: float | None = None
     cfg_scale_speaker: float | None = None
     cfg_guidance_mode: Literal["independent", "joint", "alternating"] | None = None
     cfg_scale: float | None = None
@@ -71,7 +71,6 @@ class IrodoriOptions(BaseModel):
     tail_std_threshold: float | None = None
     tail_mean_threshold: float | None = None
     max_text_len: int | None = None
-    max_caption_len: int | None = None
     lora_adapter: str | None = None
     chunking_enabled: bool | None = None
     chunk_min_chars: int | None = None
@@ -180,6 +179,7 @@ def health() -> dict[str, Any]:
             "load_timeout": settings.model_load_timeout,
             "max_concurrent_synthesis": settings.max_concurrent_synthesis,
             "synthesis_wait_timeout": settings.synthesis_wait_timeout,
+            "use_caption_condition": runtime_manager.use_caption_condition,
         },
         "voices": {
             "dir": str(voices_dir),
@@ -220,7 +220,6 @@ def list_voices() -> dict[str, Any]:
                 "object": "voice",
                 "ref_wav": voice.ref_wav,
                 "ref_latent": voice.ref_latent,
-                "ref_embed": voice.ref_embed,
                 "no_ref": voice.no_ref,
             }
         )
@@ -412,28 +411,19 @@ def _resolve_voice(payload: SpeechRequest) -> VoiceSpec:
     options = payload.irodori
     explicit_ref_wav = options.ref_wav
     explicit_ref_latent = options.ref_latent
-    explicit_ref_embed = options.ref_embed
     explicit_no_ref = options.no_ref
     if explicit_ref_wav is None:
         explicit_ref_wav = _extra(payload, "ref_wav")
     if explicit_ref_latent is None:
         explicit_ref_latent = _extra(payload, "ref_latent")
-    if explicit_ref_embed is None:
-        explicit_ref_embed = _extra(payload, "ref_embed")
     if explicit_no_ref is None:
         explicit_no_ref = _extra(payload, "no_ref")
 
-    if (
-        explicit_ref_wav is not None
-        or explicit_ref_latent is not None
-        or explicit_ref_embed is not None
-        or explicit_no_ref
-    ):
+    if explicit_ref_wav is not None or explicit_ref_latent is not None or explicit_no_ref:
         return VoiceSpec(
             voice_id="request",
             ref_wav=None if explicit_ref_wav is None else str(explicit_ref_wav),
             ref_latent=None if explicit_ref_latent is None else str(explicit_ref_latent),
-            ref_embed=None if explicit_ref_embed is None else str(explicit_ref_embed),
             no_ref=bool(explicit_no_ref),
         )
     try:
@@ -781,15 +771,16 @@ def _build_sampling_request(payload: SpeechRequest, voice: VoiceSpec) -> Samplin
     if seconds is not None and payload.speed != 1.0:
         seconds = _as_float(seconds, "seconds") / float(payload.speed)
 
+    caption = _as_optional_str(
+        _coalesce(opts.caption, _extra(payload, "caption"), None),
+        "caption",
+    )
+
     return SamplingRequest(
         text=payload.input,
-        caption=_as_optional_str(
-            _coalesce(opts.caption, _extra(payload, "caption"), None),
-            "caption",
-        ),
+        caption=caption,
         ref_wav=voice.ref_wav,
         ref_latent=voice.ref_latent,
-        ref_embed=voice.ref_embed,
         no_ref=bool(voice.no_ref),
         ref_normalize_db=_as_optional_float(
             _explicit_option(
@@ -846,7 +837,11 @@ def _build_sampling_request(payload: SpeechRequest, voice: VoiceSpec) -> Samplin
             "max_text_len",
         ),
         max_caption_len=_as_optional_int(
-            _coalesce(opts.max_caption_len, _extra(payload, "max_caption_len"), None),
+            _coalesce(
+                opts.max_caption_len,
+                _extra(payload, "max_caption_len"),
+                settings.default_max_caption_len,
+            ),
             "max_caption_len",
         ),
         num_steps=_as_int(
@@ -865,7 +860,7 @@ def _build_sampling_request(payload: SpeechRequest, voice: VoiceSpec) -> Samplin
             _coalesce(
                 opts.cfg_scale_caption,
                 _extra(payload, "cfg_scale_caption"),
-                settings.default_cfg_scale_text,
+                settings.default_cfg_scale_caption,
             ),
             "cfg_scale_caption",
         ),

--- a/src/irodori_openai_tts/app.py
+++ b/src/irodori_openai_tts/app.py
@@ -37,9 +37,9 @@ class IrodoriOptions(BaseModel):
     ref_wav: str | None = None
     ref_latent: str | None = None
     no_ref: bool | None = None
-    caption: str | None = None
+    text: str | None = None
     max_caption_len: int | None = None
-    cfg_scale_caption: float | None = None
+    caption_scale: float | None = None
     seconds: float | None = None
     duration_scale: float | None = None
     min_seconds: float | None = None
@@ -52,8 +52,8 @@ class IrodoriOptions(BaseModel):
     sway_coeff: float | None = None
     num_candidates: int | None = None
     decode_mode: Literal["sequential", "batch"] | None = None
-    cfg_scale_text: float | None = None
-    cfg_scale_speaker: float | None = None
+    text_scale: float | None = None
+    speaker_scale: float | None = None
     cfg_guidance_mode: Literal["independent", "joint", "alternating"] | None = None
     cfg_scale: float | None = None
     cfg_min_t: float | None = None
@@ -90,6 +90,7 @@ class SpeechRequest(BaseModel):
 
 
 settings = get_settings()
+print(settings)
 runtime_manager = RuntimeManager(settings)
 voice_registry = VoiceRegistry(settings)
 
@@ -772,7 +773,7 @@ def _build_sampling_request(payload: SpeechRequest, voice: VoiceSpec) -> Samplin
         seconds = _as_float(seconds, "seconds") / float(payload.speed)
 
     caption = _as_optional_str(
-        _coalesce(opts.caption, _extra(payload, "caption"), None),
+        _coalesce(opts.text, _extra(payload, "caption"), None),
         "caption",
     )
 
@@ -850,27 +851,27 @@ def _build_sampling_request(payload: SpeechRequest, voice: VoiceSpec) -> Samplin
         ),
         cfg_scale_text=_as_float(
             _coalesce(
-                opts.cfg_scale_text,
-                _extra(payload, "cfg_scale_text"),
-                settings.default_cfg_scale_text,
+                opts.text_scale,
+                _extra(payload, "text_scale"),
+                settings.default_text_scale,
             ),
-            "cfg_scale_text",
+            "text_scale",
         ),
         cfg_scale_caption=_as_float(
             _coalesce(
-                opts.cfg_scale_caption,
-                _extra(payload, "cfg_scale_caption"),
-                settings.default_cfg_scale_caption,
+                opts.caption_scale,
+                _extra(payload, "caption_scale"),
+                settings.default_caption_scale,
             ),
-            "cfg_scale_caption",
+            "caption_scale",
         ),
         cfg_scale_speaker=_as_float(
             _coalesce(
-                opts.cfg_scale_speaker,
-                _extra(payload, "cfg_scale_speaker"),
-                settings.default_cfg_scale_speaker,
+                opts.speaker_scale,
+                _extra(payload, "speaker_scale"),
+                settings.default_speaker_scale,
             ),
-            "cfg_scale_speaker",
+            "speaker_scale",
         ),
         cfg_guidance_mode=str(
             _coalesce(

--- a/src/irodori_openai_tts/config.py
+++ b/src/irodori_openai_tts/config.py
@@ -50,8 +50,10 @@ class Settings(BaseSettings):
     default_min_seconds: float = 0.5
     default_max_seconds: float = 30.0
     default_cfg_scale_text: float = 3.0
+    default_cfg_scale_caption: float = 3.0
     default_cfg_scale_speaker: float = 5.0
     default_cfg_guidance_mode: str = "independent"
+    default_max_caption_len: int | None = None
     default_cfg_min_t: float = 0.5
     default_cfg_max_t: float = 1.0
     default_context_kv_cache: bool = True

--- a/src/irodori_openai_tts/config.py
+++ b/src/irodori_openai_tts/config.py
@@ -49,9 +49,9 @@ class Settings(BaseSettings):
     default_duration_scale: float = 1.0
     default_min_seconds: float = 0.5
     default_max_seconds: float = 30.0
-    default_cfg_scale_text: float = 3.0
-    default_cfg_scale_caption: float = 3.0
-    default_cfg_scale_speaker: float = 5.0
+    default_text_scale: float = 3.0
+    default_caption_scale: float = 3.0
+    default_speaker_scale: float = 5.0
     default_cfg_guidance_mode: str = "independent"
     default_max_caption_len: int | None = None
     default_cfg_min_t: float = 0.5

--- a/src/irodori_openai_tts/runtime.py
+++ b/src/irodori_openai_tts/runtime.py
@@ -78,6 +78,12 @@ class RuntimeManager:
     def is_loading(self) -> bool:
         return self._runtime is None and self._lock.locked()
 
+    @property
+    def use_caption_condition(self) -> bool | None:
+        if self._runtime is None:
+            return None
+        return bool(self._runtime.model_cfg.use_caption_condition)
+
     def _resolve_checkpoint_path(self) -> str:
         if self.settings.checkpoint is not None and str(self.settings.checkpoint).strip() != "":
             path = Path(str(self.settings.checkpoint)).expanduser()


### PR DESCRIPTION
# 概要・変更点
Irodori-TTS-Serverで音声以外にテキストで声色を指定する機能を追加します。
既存のパラメータに加え、`caption`,`text`,`caption_scale`,`speaker_scale`を追加します。

それぞれの機能は以下の通りです。
* `caption`: `caption:{}` の形式でテキストによるキャプションを指定します。(任意)

以降はcaption内に記述します。


* `text`:テキストによる指示内容を指定します。(必須)
* `caption_scale`:テキストによる指示の影響を設定します。(任意)
* `speaker_scale`:元音声からの影響を設定します。(任意)

# 背景

Irodori-TTS-Serverを使用する際微調整をしたいと思った時や明示的にプロンプトを書くことができず、Irodori-TTSを開きなおす必要がありました。
また、Irodori-TTSをCLIから実行してもモデルロードに時間がかかってしまいます。
そのためサーバーのAPIから操作できるように機能を追加しました。

# 例

### 音声のみ生成
```bat
curl http://localhost:8088/v1/audio/speech ^
  -H "Content-Type: application/json" ^
  -d "{\"model\": \"irodori-tts\", \"input\": \"明日の天気は一日中晴れ\", \"voice\": \"sample\", \"response_format\": \"wav\"}" ^
  --output speech.wav
```
[speech.wav](https://github.com/user-attachments/files/30107293/speech.wav)


### 音声+テキスト生成
```bat
curl http://localhost:8088/v1/audio/speech ^
  -H "Content-Type: application/json" ^
  -d "{\"model\": \"irodori-tts\", \"input\": \"今日の天気は一日中晴れ。\", \"voice\": \"sample\", \"response_format\": \"wav\", \"caption\": {\"text\": \"参照音声より少し大人っぽくして。\", \"caption_scale\": 8, \"speaker_scale\": 2, \"no_ref\": false}}" ^
  --output speech.wav
```
[.speech.wav](https://github.com/user-attachments/files/30107296/default.speech.wav)

### テキストのみ生成

```bat
curl http://localhost:8088/v1/audio/speech ^
  -H "Content-Type: application/json" ^
  -d "{\"model\": \"irodori-tts\", \"input\": \"今日の天気は一日中晴れ。\", \"voice\": \"None\", \"response_format\": \"wav\", \"caption\": {\"text\": \"落ち着いた、近い距離感の女性話者\", \"no_ref\": true}}" ^
  --output speech.wav
```
[speech.wav](https://github.com/user-attachments/files/30107371/speech.wav)
